### PR TITLE
Replace channel with async event stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,6 +302,7 @@ checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
  "bitflags 2.6.0",
  "crossterm_winapi",
+ "futures-core",
  "mio",
  "parking_lot",
  "rustix",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 common = { path = "../common" }
-crossterm = "0.28.1"
+crossterm = { version = "0.28.1", features = ["event-stream"] }
 ewebsock = "0.7.0"
 futures-util = "0.3.31"
 openssl = "0.10.68"


### PR DESCRIPTION
I don't even know how your `read_console_input` function works at all. Calling `crossterm::event::read()` should block the async runtime until an input is read, which would halt your entire program until something happened. 